### PR TITLE
Upgrade Jackson and add explicit dependency

### DIFF
--- a/allure2-model-jackson/pom.xml
+++ b/allure2-model-jackson/pom.xml
@@ -21,13 +21,18 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.0</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jaxb-annotations</artifactId>
-            <version>2.7.0</version>
+            <version>2.9.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixes #13 
Adding jackson-core explicitly to avoid dependency resolution issue. Also, bumping Jackson version to 2.9.0